### PR TITLE
Locale detection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -268,7 +268,13 @@ var app = new Vue({
     }
   },
   created: function() {
-    this.locale = window.localStorage.getItem('locale') || 'en';
+    this.locale = window.localStorage.getItem('locale') ||
+      window.navigator.languages
+        .map(function (l) { return l.split('-')[0]; })
+        .filter(function (l) { return !!i18nMsgs[l]; })[0] ||
+      window.navigator.language.split('-')[0];
+
+    if (!i18nMsgs[this.locale]) this.locale = 'en';
 
     var self = this;
 


### PR DESCRIPTION
If no language was set in localStorage, checks the navigator.languages array and navigator.language property for supported languages before falling back to "en".