### PR TITLE
Replace spaces with underscores for bcc field

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -417,6 +417,7 @@ var app = new Vue({
           code = this.constituencyCode;
           break;
       }
+      code = code.replace(/ /g, '_')
       return (code + '@email.speakforme.in').toLowerCase();
     },
     twitter: function() {


### PR DESCRIPTION
The bcc field may contain spaces for some of the Services names,
replace them with underscores (and not hyphens since that may break
processing in the backend) before making the bcc email.