### PR TITLE
Trim the email field

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -539,7 +539,7 @@ var app = new Vue({
           return t.trim().length > 0;
         })
         .map(function(e) {
-          return self.personName + ' <' + e + '>';
+          return self.personName + ' <' + e.trim() + '>';
         })
         .join(', ');
     },


### PR DESCRIPTION
The services YML ends up having a newline at the end of every email
string.  Strip it before constructing the full email address.