### PR TITLE
Resurrect the email.trim()

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -578,9 +578,12 @@ var app = new Vue({
         .replace(/[\[\(]at[\]\)]/g, '@')
         .replace(' ', ',')
         .split(',')
+        .map(function(t) {
+          return t.trim();
+	})
         .filter(function(t) {
-          return t.trim().length > 0;
-        });
+          return t.length > 0;
+	});
 
       return e.join(', ');
     },


### PR DESCRIPTION
email trimming was lost when we added partialEmail, thus regressing
the PAN submission for gmail.  Trim in this.partialEmail and let
this.email inherit it.