### PR TITLE
Give the lang search string first preference

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -327,8 +327,8 @@ var app = new Vue({
     autodetect = autodetect[autodetect.length - 1].substr(0,2);
 
     var locale = (this.locale =
-      window.localStorage.getItem('locale') ||
       autodetect ||
+      window.localStorage.getItem('locale') ||
       window.navigator.languages
         .map(function(l) {
           return l.split('-')[0];


### PR DESCRIPTION
Fixes #97.

The ?lang=locale option has no use if it is not the first option to be
selected since the localStorage option is otherwise persistent.  By
giving it first preference, here are the possible interaction
scenarios:

- User visits using the search string and gets the desired language
  - Sees desired language, hence happy
- User browses to another page
  - Sees language persist despite losing the search string, hence happier
- User changes language for whatever reason
  - Sees selected language, even happier
- User browses to another page
  - Sees language selection persist, happiest!