### PR TITLE
Redirect /mp/ to homepage

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,4 @@
 # See https://www.netlify.com/docs/redirects/
 # Does a 301 by default, so be careful
 /         /optout/      302
+/mp/	  /optout/	302


### PR DESCRIPTION
Reported by Nakul Shenoy.

> * Google search for 'Speak For Me' returns the ever popular MP page, which when clicked returns a 'page not found' as it does not exist. 